### PR TITLE
Added support for client credentials flow

### DIFF
--- a/ramp_client/client.py
+++ b/ramp_client/client.py
@@ -177,6 +177,7 @@ class RampClient(object):
         self.s = None
 
         self.access_token = access_token
+        self.refresh_token = None
         self.client_id = client_id
         self.client_secret = client_secret
         self.redirect_uri = redirect_uri


### PR DESCRIPTION
**Changes**:
* Added support for OAuth Client Credentials flow. As an example,
```python
from ramp_client.client import RampClient, GrantType

c = RampClient(
    client_id="<ID>",
    client_secret="<SECRET>",
    grant_type=GrantType.CLIENT_CREDENTIALS,
    scopes=["transactions:read"]
)
```

**Bug Fixes**:
* Ensure `refresh_token` attribute on `RampClient` is always set, even if it isn't used