### PR TITLE
feat: backoff and retries

### DIFF
--- a/ramp_client/client.py
+++ b/ramp_client/client.py
@@ -165,7 +165,7 @@ class RampClient(object):
         params=None, 
         data=None, 
         json=None, 
-        headers={}, 
+        headers=None, 
         retry: bool = True, 
         **kwargs,
     ):
@@ -173,7 +173,8 @@ class RampClient(object):
         # print(url)
         s = self.get_session()
 
-        s.headers.update(headers)
+        if headers is not None:
+            s.headers.update(headers)
 
         default_timeout = kwargs.pop("timeout", 60)
 

--- a/ramp_client/client.py
+++ b/ramp_client/client.py
@@ -158,22 +158,50 @@ class RampClient(object):
             getattr(err, "response", None) is None or err.response.status_code != 429
         ),
     )
-    def hit_api(self, verb, endpoint, params=None, data=None, json=None, headers={}, retry: bool = True):
+    def hit_api(
+        self, 
+        verb, 
+        endpoint, 
+        params=None, 
+        data=None, 
+        json=None, 
+        headers={}, 
+        retry: bool = True, 
+        **kwargs,
+    ):
         url = "{}{}".format(self.base_url, endpoint)
         # print(url)
         s = self.get_session()
 
         s.headers.update(headers)
 
+        default_timeout = kwargs.pop("timeout", 60)
+
         #print (s.headers)
-        res = s.request(verb, url=url, data=data, params=params, json=json)
+        res = s.request(
+            verb, 
+            url=url, 
+            data=data, 
+            params=params, 
+            json=json,
+            timeout=default_timeout,
+            **kwargs,
+        )
         # print(res.status_code)
         if res.status_code == 401:
             # print("need to re auth")
             self.access_token = None
             self.build_auth()
             s = self.get_session()
-            res = s.request(verb, url=url, data=data, params=params, json=json)
+            res = s.request(
+                verb, 
+                url=url, 
+                data=data, 
+                params=params, 
+                json=json,
+                timeout=default_timeout,
+                **kwargs,
+            )
             # print("second status code", res.status_code)
         # TODO: Not sure if they send the `Retry-After` header.
         # Something to consider in the the future.

--- a/ramp_client/client.py
+++ b/ramp_client/client.py
@@ -158,7 +158,7 @@ class RampClient(object):
             getattr(err, "response", None) is None or err.response.status_code != 429
         ),
     )
-    def hit_api(self, verb, endpoint, params=None, data=None, json=None, headers={}, allow_retries: bool = True):
+    def hit_api(self, verb, endpoint, params=None, data=None, json=None, headers={}, retry: bool = True):
         url = "{}{}".format(self.base_url, endpoint)
         # print(url)
         s = self.get_session()
@@ -177,7 +177,7 @@ class RampClient(object):
             # print("second status code", res.status_code)
         # TODO: Not sure if they send the `Retry-After` header.
         # Something to consider in the the future.
-        if allow_retries and res.status_code == 429:
+        if retry and res.status_code == 429:
             # To allow users to decide if they
             # want to retry, we need to ensure 429-exceptions
             # aren't thrown so it never makes through `backoff`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 requests~=2.27.1
 simplejson~=3.17.6
 six~=1.16.0
+backoff>=1.8<2.0


### PR DESCRIPTION
**Changes**:
* By default, retry requests when 429-related HTTP error encountered. Users can optionally disable this by passing `retry=False` when calling `RampClient.hit_api`.
* Added `backoff>=1.8<2.0` dependency
* Allow users to pass additional `requests.request`-compatible keyword arguments when calling `RampClient.hit_api`.
* Set default `requests` connect/read timeout to 60 seconds.